### PR TITLE
TRE-49 add feature "min-algo" to disable mining difficulty adjustment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4168,7 +4168,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-rewards"
-version = "0.1.0"
+version = "0.10.0-dev"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7744,7 +7744,7 @@ dependencies = [
 
 [[package]]
 name = "trex-constants"
-version = "0.1.0"
+version = "0.10.0-dev"
 
 [[package]]
 name = "trex-inherent"
@@ -7763,7 +7763,7 @@ dependencies = [
 
 [[package]]
 name = "trex-node"
-version = "4.0.1-dev"
+version = "0.10.0-dev"
 dependencies = [
  "clap 3.2.8",
  "elgamal_trex",
@@ -7811,11 +7811,12 @@ dependencies = [
 
 [[package]]
 name = "trex-pow"
-version = "0.1.0"
+version = "0.10.0-dev"
 dependencies = [
  "blake3",
  "criterion",
  "elgamal_trex",
+ "log",
  "parity-scale-codec",
  "rand 0.8.5",
  "rug",

--- a/README.md
+++ b/README.md
@@ -53,6 +53,14 @@ The provided `cargo run` command will launch a temporary node and its state will
 you terminate the process. After the project has been built, there are other ways to launch the
 node.
 
+### Disable/Enable Mining Difficulty Adjustment
+In case of testing & development, the mining difficulty adjustment may be turned off by adding feature "min-algo" 
+to the `cargo run` command so that the minimal mining algorithm will be used (without difficulty adjustment).
+
+```sh
+cargo run --release --features min-algo -- --dev --tmp
+```
+
 ### Single-Node Development Chain
 
 This command will start the single-node development chain with non-persistent state:

--- a/consensus/trex-pow/Cargo.toml
+++ b/consensus/trex-pow/Cargo.toml
@@ -14,6 +14,7 @@ codec = { package = "parity-scale-codec", version = "3.0.0" }
 rand = { version = "0.8", features = ["small_rng"] }
 rug = "1.14.1"
 blake3 = "1.3.1"
+log = '0.4.8'
 
 # Substrate packages
 sc-consensus-pow = { version = "0.10.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.24" }

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -81,3 +81,5 @@ default = []
 runtime-benchmarks = [
 	"trex-runtime/runtime-benchmarks",
 ]
+# if using minimal algorithm, there is no difficulty adjustment.
+min-algo = []

--- a/node/src/mining.rs
+++ b/node/src/mining.rs
@@ -29,7 +29,7 @@ pub fn generate_mining_seed(
     // TODO: if the runtime info problem is resolved, this part of code is no longer necessary.
     info!(
 			target: "sub-libp2p",
-			"🏷  Local node identity is: {}",
+			"🏷 Local node identity is: {}",
 			local_peer_id.to_base58(),
 		);
     // Return Result containing mining_key


### PR DESCRIPTION
1. TRE-49 add the feature "min-algo" to disable mining difficulty adjustment and added the corresponding doc in README.md.

2. TRE-36 fix unwanted debug macro string and replace it with info macro.